### PR TITLE
Add second buffer for partial bounding boxes detection

### DIFF
--- a/Cropper.py
+++ b/Cropper.py
@@ -75,15 +75,20 @@ class Cropper():
         else:
             return x_center_norm, y_center_norm, w_norm, h_norm
     
-    def inZone(self,left,top,w,h):
+    def inZone(self,left,top,w,h, parking):
         cam0 = [[(0,0), (0,128), (98,186), (348,118), (430,115),(668,0)], [(747,0), (690,145), (730,148), (760,0)], [(816,0), (1083,195), (1280,234),(1280,0)]]
         cam1 = [[(0,0), (0,137), (1024,276), (1280,248)], [(0,172), (0,219), (719,396), (824,358)]]
         cam2 = [[(0,0), (0,322), (81,298), (422,98), (422,0)], [(476,0), (484,308), (611,295), (543,163), (543,0)], [(562,0), (562,99), (1077,299), (1280,325), (1280,0)]]
         cam3 = [[(0,0), (0,345), (260,267), (260,0)], [(5,720), (340,272), (439.720)], [(366,0), (366,272), (1280,476), (1280,0)]]
-        cam4 = [[(0,0), (0,356), (728,0)], [(783,0), (620,363), (734,366)], [(857,0), (1280,356), (1280,0)]]
+        cam4 = [[(283,0), (283,269), (751,0)], [(783,0), (620,363), (734,366)], [(811,0), (1280,480), (1280,0)]]
         cam5 = [[(0,0), (0,283), (74,265), (58,0)], [(0,330), (0,642), (209,590), (109,324)], [(58,0), (68,183), (666,276), (1280,237), (1280,0)], [(731,308), (1280,428), (1280,278)]]
         cam6 = [[(0,0), (0,170), (1280,163), (1280,0)], [(0,200), (0,278), (164,195)], [(712,183), (1058,326), (1280,337), (1280,190)]]
         cam7 = [[(0,97), (0,327), (260,175)], [(310,190), (312,720), (452,720)], [(0,0), (1280,478), (0,97), (1280,478), (1280,0)]]
+
+        if parking:    #allow parallel parking
+             cam3 = [[(0,0), (0,366), (239,267), (239,0)], [(5,720), (340,272), (439.720)], [(366,0), (366,272), (1280,476), (1280,0)]]
+             cam4 = [[(291,0), (291,187), (700,0)], [(783,0), (620,363), (734,366)], [(836,0), (1280,275), (1280,0)]]
+
 
         zones = [cam0, cam1, cam2, cam3, cam4, cam5, cam6, cam7]
 
@@ -102,7 +107,7 @@ class Cropper():
             return False
 
 
-    def crop_frame(self, image_path, label_path, multi=False):
+    def crop_frame(self, image_path, label_path, parking, multi=False):
 
         """
         Crop regions of interest from the image based on bounding box information.
@@ -143,7 +148,7 @@ class Cropper():
                 x_center_norm, y_center_norm, w_norm, h_norm = self.get_image_info(info)
             left, top, w, h = self.convert(W, H, x_center_norm, y_center_norm, w_norm, h_norm)
             
-            if not self.inZone(left, top, w, h) and self.sizeCheck(w, h):
+            if not self.inZone(left, top, w, h, parking) and self.sizeCheck(w, h):
                 if multi:
                     info_list.append([left, top, left+w, top+h, id_])
                     info_list_norm.append([x_center_norm, y_center_norm, w_norm, h_norm, id_])

--- a/Cropper.py
+++ b/Cropper.py
@@ -75,7 +75,7 @@ class Cropper():
         else:
             return x_center_norm, y_center_norm, w_norm, h_norm
     
-    def inZone(self,left,top,w,h, parking):
+    def inZone(self,left,top,w,h, parking=True):
         cam0 = [[(0,0), (0,128), (98,186), (348,118), (430,115),(668,0)], [(747,0), (690,145), (730,148), (760,0)], [(816,0), (1083,195), (1280,234),(1280,0)]]
         cam1 = [[(0,0), (0,137), (1024,276), (1280,248)], [(0,172), (0,219), (719,396), (824,358)]]
         cam2 = [[(0,0), (0,322), (81,298), (422,98), (422,0)], [(476,0), (484,308), (611,295), (543,163), (543,0)], [(562,0), (562,99), (1077,299), (1280,325), (1280,0)]]
@@ -107,7 +107,7 @@ class Cropper():
             return False
 
 
-    def crop_frame(self, image_path, label_path, parking, multi=False):
+    def crop_frame(self, image_path, label_path, parking=True, multi=False):
 
         """
         Crop regions of interest from the image based on bounding box information.

--- a/Matcher.py
+++ b/Matcher.py
@@ -3,7 +3,7 @@ import numpy as np
 ERROR = 10
 class Matcher():
 
-    def __init__(self, threshold=0.5, buffer_size=1, lambda_value=0.8):
+    def __init__(self, threshold=0.5, buffer_size=1, lambda_value=0.8, partial_threshold=0.5):
 
         """
         Initialize the Matcher class with threshold, buffer size, and lambda value.
@@ -15,6 +15,7 @@ class Matcher():
         """
 
         self.threshold = threshold
+        self.partial_threshold = partial_threshold
         self.buffer_size = buffer_size
         self.object_buffer = [] # Object buffer stores information about tracked objects
         self.partial_object_buffer = [] # Object buffer stores information about the top, left and right halves and top left, top right corners of tracked objects
@@ -485,7 +486,7 @@ class Matcher():
 
 
     
-    def get_ensemble_id_list(self, object_embeddings, info_list, dist_matrices, cam, rerank=True):
+    def get_ensemble_id_list(self, object_embeddings, info_list, dist_matrices, partial_dist_matrices, cam, rerank=True):
         """
         Match current objects to existing objects in the object buffer or assign new IDs.
 
@@ -545,7 +546,6 @@ class Matcher():
                     for idx in range(len(object_embeddings)):
 
                         if id_list[idx] != -1 or not(self.nearBorder(info_list[idx], cam)):
-
                             continue
 
                         for i, matrix in enumerate(partial_dist_matrices):
@@ -690,7 +690,6 @@ class Matcher():
                     for idx in range(len(object_embeddings)):
 
                         if id_list[idx] != -1 or not(self.nearBorder(info_list[idx], cam)):
-
                             continue
 
                         for i, matrix in enumerate(partial_dist_matrices):

--- a/Matcher.py
+++ b/Matcher.py
@@ -19,6 +19,7 @@ class Matcher():
         self.object_buffer = [] # Object buffer stores information about tracked objects
         self.partial_object_buffer = [] # Object buffer stores information about the top, left and right halves and top left, top right corners of tracked objects
         self.object_in_frame = [] # Number of objects in each frame
+        self.partial_object_in_frame = [] # Number of partial objects in each frame
         self.id = 0 # Current ID for assigning to new objects
         self.lambda_value = lambda_value
     

--- a/Matcher.py
+++ b/Matcher.py
@@ -761,7 +761,7 @@ class Matcher():
         self.partial_object_in_frame.append(len(object_embeddings)*5)
 
         # Matching objects to existing objects in the object buffer
-        if self.object_buffer and object_embeddings.size != 0:
+        if self.object_buffer and object_embeddings.numel() != 0:
             
             #get the average distance matrix
             for i, matrix in enumerate(dist_matrices):

--- a/Matcher.py
+++ b/Matcher.py
@@ -376,7 +376,7 @@ class Matcher():
         return dist_matrix
 
 
-        def compute_partial_distmatrix(self, object_embeddings):
+    def compute_partial_distmatrix(self, object_embeddings):
 
         """
         Compute the cosine similarity distance matrix between current object embeddings and existing partial object embeddings.

--- a/Matcher.py
+++ b/Matcher.py
@@ -439,9 +439,52 @@ class Matcher():
         return matched, motion
     
 
+    def nearBorder(self, info, cam):
+        '''
+        Return True if the object is near the border of the frame, False otherwise.
+
+        Args:
+        - info (list): Information about the object.
+
+        Returns:
+        - bool: True if the object is near the border, False otherwise.
+        '''
+        left_x = info[0]
+        top_y = info[1]
+        right_x = info[2]
+        bottom_y = info[3]
+
+        if cam == 0:
+            if right_x <= 613 and bottom_y >= 710:
+                return True
+        elif cam == 1:
+            if (right_x >= 1270 and top_y >= 406) or bottom_y >= 710:
+                return True
+        elif cam == 2:
+            if right_x <= 596 and bottom_y >= 710:
+                return True
+        elif cam == 3:
+            if left_x <= 10 and top_y >= 290:
+                return True
+        elif cam == 4:
+            if (left_x <= 10 and top_y >= 312) or (right_x <= 624 and bottom_y >= 710):
+                return True 
+        elif cam == 5:
+            if left_x >= 213 and bottom_y >= 710:
+                return True
+        elif cam == 6:
+            return False
+        elif cam == 7:
+            if (left_x <= 10 and top_y >= 338) or (right_x <= 300 and bottom_y >= 710):
+                return True
+
+        return False
+
+
+
 
     
-    def get_ensemble_id_list(self, object_embeddings, info_list, dist_matrices, rerank=True):
+    def get_ensemble_id_list(self, object_embeddings, info_list, dist_matrices, cam, rerank=True):
         """
         Match current objects to existing objects in the object buffer or assign new IDs.
 
@@ -500,7 +543,7 @@ class Matcher():
                 if any(x == -1 for x in id_list) :
                     for idx in range(len(object_embeddings)):
 
-                        if id_list[idx] != -1 or info_list[idx][3] < 710:
+                        if id_list[idx] != -1 or not(self.nearBorder(info_list[idx], cam)):
 
                             continue
 
@@ -645,7 +688,7 @@ class Matcher():
                 if any(x == -1 for x in id_list) :
                     for idx in range(len(object_embeddings)):
 
-                        if id_list[idx] != -1 or info_list[idx][3] < 710:
+                        if id_list[idx] != -1 or not(self.nearBorder(info_list[idx], cam)):
 
                             continue
 

--- a/ensemble.py
+++ b/ensemble.py
@@ -44,7 +44,7 @@ if __name__ == '__main__':
     parser.add_argument('--finetune', default=False, type=bool, help='Specify whether in finetune mode')
     parser.add_argument('--re_rank', type=bool, default=False)
     parser.add_argument('--min_size', default=0, type=float, help='Minimum size of the object to be cropped')
-    parser.add_argument('--use_partial', action='store_true', type=bool, help='Specify whether to use partial distance matrix')
+    parser.add_argument('--use_partial', action='store_true', help='Specify whether to use partial distance matrix')
     args = parser.parse_args()
 
 

--- a/ensemble.py
+++ b/ensemble.py
@@ -44,6 +44,7 @@ if __name__ == '__main__':
     parser.add_argument('--finetune', default=False, type=bool, help='Specify whether in finetune mode')
     parser.add_argument('--re_rank', type=bool, default=False)
     parser.add_argument('--min_size', default=0, type=float, help='Minimum size of the object to be cropped')
+    parser.add_argument('--use_partial', action='store_true', type=bool, help='Specify whether to use partial distance matrix')
     args = parser.parse_args()
 
 
@@ -146,7 +147,7 @@ if __name__ == '__main__':
 
 
             # Match object embeddings to previous frames
-            id_list=  matcher.get_ensemble_id_list(object_embeddings, info_list, model_dist_mats, model_partial_dist_mats, args.cam, args.re_rank)
+            id_list=  matcher.get_ensemble_id_list(object_embeddings, info_list, model_dist_mats, model_partial_dist_mats, args.cam, args.use_partial, args.re_rank)
 
             # Record coordinates and IDs to the output file
             for n in range(len(info_list)):

--- a/ensemble.py
+++ b/ensemble.py
@@ -123,7 +123,7 @@ if __name__ == '__main__':
                 info_list_norm = json.load(f)
 
             #load embeddings for this frame
-            object_embeddings = np.load(os.path.join(args.dist_dir,f"{args.out.split('/')[-1]}",models_files_folder[0],str(args.cam),f'{frame_id}_embeddings.npy'))
+            object_embeddings = torch.load(os.path.join(args.dist_dir,f"{args.out.split('/')[-1]}",models_files_folder[0],str(args.cam),f'{frame_id}_embeddings.pt'))
 
 
             # Open a text file to record the label of each frame
@@ -136,14 +136,17 @@ if __name__ == '__main__':
 
             #load distance matrices from all models
             model_dist_mats = []
+            model_partial_dist_mats = []
             for model in models_files_folder:
-                matrix = torch.load(os.path.join(args.dist_dir,f"{args.out.split('/')[-1]}",model,str(args.cam), f'{frame_id}.pt'))
+                matrix = torch.load(os.path.join(args.dist_dir,f"{args.out.split('/')[-1]}",model,str(args.cam), f'{frame_id}_whole.pt'))
                 model_dist_mats.append(matrix)
 
+                partial_matrix = torch.load(os.path.join(args.dist_dir,f"{args.out.split('/')[-1]}",model,str(args.cam), f'{frame_id}_partial.pt'))
+                model_partial_dist_mats.append(partial_matrix)
 
 
             # Match object embeddings to previous frames
-            id_list=  matcher.get_ensemble_id_list(np.array(object_embeddings), info_list, model_dist_mats, args.re_rank)
+            id_list=  matcher.get_ensemble_id_list(object_embeddings, info_list, model_dist_mats, model_partial_dist_mats, args.re_rank)
 
             # Record coordinates and IDs to the output file
             for n in range(len(info_list)):

--- a/ensemble.py
+++ b/ensemble.py
@@ -146,7 +146,7 @@ if __name__ == '__main__':
 
 
             # Match object embeddings to previous frames
-            id_list=  matcher.get_ensemble_id_list(object_embeddings, info_list, model_dist_mats, model_partial_dist_mats, args.re_rank)
+            id_list=  matcher.get_ensemble_id_list(object_embeddings, info_list, model_dist_mats, model_partial_dist_mats, args.cam, args.re_rank)
 
             # Record coordinates and IDs to the output file
             for n in range(len(info_list)):

--- a/main.py
+++ b/main.py
@@ -46,6 +46,7 @@ if __name__ == '__main__':
     parser.add_argument('--output_ensemble', default=False, type=bool, help='Output model files for ensemble')
     parser.add_argument('--min_size', default=0, type=float, help='Minimum size of the object to be cropped')
     parser.add_argument('--parking', action='store_true', help='Specify whether to include parallel parking cars')
+    parser.add_argument('--use_partial', action='store_true', help='Specify whether to use partial distance matrix')
 
 
     args = parser.parse_args()
@@ -170,7 +171,7 @@ if __name__ == '__main__':
                 partial_embeddings = partial_embeddings / partial_embedding_norm
 
             # Match object embeddings to previous frames
-            id_list, output_dist_mat, ouput_partial_dist_mat =  matcher.match(object_embeddings, partial_embeddings, info_list, args.re_rank)
+            id_list, output_dist_mat, ouput_partial_dist_mat =  matcher.match(object_embeddings, partial_embeddings, info_list, args.use_partial, args.re_rank)
 
 
             # Record coordinates and IDs to the output file

--- a/main.py
+++ b/main.py
@@ -177,6 +177,30 @@ if __name__ == '__main__':
             if args.output_ensemble:
                     save_folder = os.path.join(args.out, args.model, str(args.cam))
                     os.makedirs(save_folder, exist_ok=True)
-                    torch.save(output_dist_mat, os.path.join(os.path.join(args.out, args.model, str(args.cam)),f'{frame_id}.pt'))
+                    torch.save(output_dist_mat, os.path.join(os.path.join(args.out, args.model, str(args.cam)),f'{frame_id}_whole.pt'))
                     torch.save(ouput_partial_dist_mat, os.path.join(os.path.join(args.out, args.model, str(args.cam)),f'{frame_id}_partial.pt'))
-                    torch.save(object_embeddi
+                    torch.save(object_embeddings, os.path.join(os.path.join(args.out, args.model, str(args.cam)),f'{frame_id}_embeddings.pt'))
+                    
+                    with open(os.path.join(save_folder,f'{frame_id}_info.json'), 'w+') as f:
+                        json.dump(info_list, f)
+                    with open(os.path.join(save_folder,f'{frame_id}_info_norm.json'), 'w+') as f:
+                        json.dump(info_list_norm, f)
+
+                    
+
+            frame_id += 1
+
+            # Draw bounding boxes if visualization is enabled
+            if args.visualize:
+                image = cv2.imread(imgs[i])
+                for n in range(len(info_list)):
+                    color = palette.get_color(id_list[n])
+                    cv2.rectangle(image, (info_list[n][0], info_list[n][1]), (info_list[n][2], info_list[n][3]), color, 2)
+                    cv2.putText(image, text=str(id_list[n]), org=(info_list[n][0], info_list[n][1] - 5), fontFace=cv2.FONT_HERSHEY_SIMPLEX, fontScale=2, color=color, thickness=3)
+
+
+                video_out.write(image)
+
+    # Release video writer if visualization is enabled
+    if args.visualize:
+        video_out.release()

--- a/main.py
+++ b/main.py
@@ -45,10 +45,10 @@ if __name__ == '__main__':
     parser.add_argument('--finetune', default=False, type=bool, help='Specify whether in finetune mode')
     parser.add_argument('--output_ensemble', default=False, type=bool, help='Output model files for ensemble')
     parser.add_argument('--min_size', default=0, type=float, help='Minimum size of the object to be cropped')
+    parser.add_argument('--parking', action='store_true', help='Specify whether to include parallel parking cars')
 
 
     args = parser.parse_args()
-
 
     
     # To check if it's in fine-tune mode
@@ -133,7 +133,7 @@ if __name__ == '__main__':
             f = open(f'{out}/{args.cam}_{frame_id:05}.txt', 'w')
 
             # Crop objects from the current frame
-            current_objects, info_list, info_list_norm = cropper.crop_frame(image_path=imgs[i], label_path=labels[i])
+            current_objects, info_list, info_list_norm = cropper.crop_frame(image_path=imgs[i], label_path=labels[i], parking=args.parking)
 
             # Extract features for each cropped object
             for j in range(len(current_objects)):
@@ -183,7 +183,7 @@ if __name__ == '__main__':
                     torch.save(output_dist_mat, os.path.join(os.path.join(args.out, args.model, str(args.cam)),f'{frame_id}_whole.pt'))
                     torch.save(ouput_partial_dist_mat, os.path.join(os.path.join(args.out, args.model, str(args.cam)),f'{frame_id}_partial.pt'))
                     torch.save(object_embeddings, os.path.join(os.path.join(args.out, args.model, str(args.cam)),f'{frame_id}_embeddings.pt'))
-                    
+
                     with open(os.path.join(save_folder,f'{frame_id}_info.json'), 'w+') as f:
                         json.dump(info_list, f)
                     with open(os.path.join(save_folder,f'{frame_id}_info_norm.json'), 'w+') as f:

--- a/main.py
+++ b/main.py
@@ -122,6 +122,7 @@ if __name__ == '__main__':
         for i in tqdm(range(len(imgs)), dynamic_ncols=True):
             current_objects = []    
             object_embeddings = torch.empty(0, 2048).to(device)
+            partial_embeddings = torch.empty(0, 2048).to(device)
             info_list = []
             info_list_norm = []
             
@@ -158,6 +159,8 @@ if __name__ == '__main__':
                 _, top_left_feature, _ = extracter(torch.unsqueeze(transform(top_left),0).to(device))
                 _, top_right_feature, _ = extracter(torch.unsqueeze(transform(top_right),0).to(device))
 
+                partial_embeddings = torch.cat((partial_embeddings, top_feature, left_feature, right_feature, top_left_feature, top_right_feature), dim=0)
+
             #embedding normalization
             if object_embeddings.numel() != 0:
                 embedding_norm = torch.linalg.norm(object_embeddings, dim=1, keepdims=True)
@@ -167,7 +170,7 @@ if __name__ == '__main__':
                 partial_embeddings = partial_embeddings / partial_embedding_norm
 
             # Match object embeddings to previous frames
-            id_list, output_dist_mat, ouput_partial_dist_mat =  matcher.match(object_embeddings, info_list, args.re_rank)
+            id_list, output_dist_mat, ouput_partial_dist_mat =  matcher.match(object_embeddings, partial_embeddings, info_list, args.re_rank)
 
 
             # Record coordinates and IDs to the output file

--- a/tools/datasets/AICUP_to_MOT15.py
+++ b/tools/datasets/AICUP_to_MOT15.py
@@ -57,7 +57,7 @@ def AI_CUP_to_MOT15(args):
                 bb_top = float(data[2]) * img_height - bb_height / 2
                 track_id = data[5].split('\n')
                 f_mot15.write(
-                    f'{str(frame_ID)},{track_id[0]},{str(bb_left)},{str(bb_top)},{str(bb_width)},{str(bb_height)},1,-1,-1,-1\n'
+                    f'{str(frame_ID)},{track_id[0]},{str(bb_left)},{str(bb_top)},{str(bb_width)},{str(bb_height)},1,-1,-1,-1\r\n'
                 )
                 
             f_aicup.close()


### PR DESCRIPTION
Add a second layer buffer for partial bounding box detection, currently it only activate when bounding box is near the bottom of the screen (10 pixels range, 720>y>710, the conditions may be adjusted). 
It's not an overall improvement on every cameras and every date, so might need to consider which camera or date to use this functionality. 
The threshold of second buffer could be adjusted, maybe it will work better with our selected parameters.

Change the file extension for storing and reading files to fit the changes on variables data types.
Remove some redundant code.
